### PR TITLE
@bot issue in ROOM

### DIFF
--- a/hangoutschat.py
+++ b/hangoutschat.py
@@ -16,7 +16,6 @@ from markdownconverter import hangoutschat_markdown_converter
 # Can't use __name__ because of Yapsy
 log = logging.getLogger('errbot.backends.hangoutschat')
 
-
 class HangoutsChatIdentifier(Identifier):
     def __init__(self, id):
         self._id = str(id)
@@ -129,6 +128,7 @@ class HangoutsChatBackend(ErrBot):
 
         event_data = json.loads(message.data)
         space_name = event_data['space']['name']
+        text = event_data['message']['text']
 
         # If the bot was added or removed, we don't need to return a response.
         if event_data['type'] == 'ADDED_TO_SPACE':
@@ -139,8 +139,14 @@ class HangoutsChatBackend(ErrBot):
             log.info('Bot removed rom space {}'.format(space_name))
             message.ack()
             return
+        
+        # Check if the space type is ROOM
+        if event_data['space']['type'] == 'ROOM':
+            # Remove @ mentions from the text
+            text = ' '.join(word for word in text.split() if not word.startswith('@'))
 
-        message_instance = self.build_message(event_data['message']['text'])
+        # message_instance = self.build_message(event_data['message']['text'])
+        message_instance = self.build_message(text)
 
         sender = event_data['message']['sender']
         message_instance.to = self.bot_identifier

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ google-cloud-pubsub
 oauth2client
 google-api-python-client
 httplib2
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ google-cloud-pubsub
 oauth2client
 google-api-python-client
 httplib2
+


### PR DESCRIPTION
Thank you for your effort in providing the Google Chat backend. 
I have found a few areas that can be adjusted. 
When calling the bot to execute commands within a space, an exception occurs because the parsing treats "@bot" as part of the Errbot command. 
To address this issue, I made modifications to remove the "@bot" string when the type is confirmed as ROOM.

> before
```bash
DEBUG    errbot.core               *** text = @bot !help
DEBUG    errbot.core               Command not found
```

> after
```bash
DEBUG    errbot.core               *** text = !help
DEBUG    errbot.plugins.ACLs       Check help for ACLs.
INFO     errbot.plugins.ACLs       Matching ACL {} against username xx@xx.xx.xx.xx for command Help:help.
DEBUG    errbot.plugins.ACLs       Check if help is admin only command.
```